### PR TITLE
Draft 2 - Add Blank Columns and Draggable Backpack

### DIFF
--- a/gameplay/Backpack.gd
+++ b/gameplay/Backpack.gd
@@ -1,3 +1,4 @@
+# Backpack to drag underneath gameplay columns.
 extends Area2D
 
 signal released

--- a/gameplay/Backpack.gd
+++ b/gameplay/Backpack.gd
@@ -7,6 +7,8 @@ var mouse_overlap = false
 var selected = false
 
 var _frame_rate = 25
+var _scale_down_original = 0.833333333333
+var _scale_up_20_percent = 1.2
 
 func _process(delta):
 	if selected:
@@ -20,20 +22,32 @@ func snap_position_to_column(gameplay_column):
 	var anchor_point = gameplay_column.get_anchor_point()
 	set_position(anchor_point)
 
+func _deselect_and_shrink_backpack():
+	released.emit()
+	selected = false
+	$Sprite2D.apply_scale(
+		Vector2(_scale_down_original, _scale_down_original)
+	)
+
 func _input(event):
 	if not Input.is_action_just_pressed("click"):
 		return
 
 	if selected:
-		released.emit()
-		selected = false
+		_deselect_and_shrink_backpack()
 		return
 
 	if mouse_overlap:
-		selected = true
+		_select_and_enlarge_backpack()
 
 func _on_mouse_entered():
 	mouse_overlap = true
 
 func _on_mouse_exited():
 	mouse_overlap = false
+
+func _select_and_enlarge_backpack():
+	selected = true
+	$Sprite2D.apply_scale(
+		Vector2(_scale_up_20_percent, _scale_up_20_percent)
+	)

--- a/gameplay/Backpack.gd
+++ b/gameplay/Backpack.gd
@@ -1,5 +1,6 @@
-extends Node2D
+extends Area2D
 
+var is_mouse_overlap = false
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
@@ -22,3 +23,9 @@ func _process(delta):
 func snap_position_to_column(gameplay_column):
 	var anchor_point = gameplay_column.get_anchor_point()
 	set_position(anchor_point)
+
+func _on_mouse_entered():
+	is_mouse_overlap = true
+
+func _on_mouse_exited():
+	is_mouse_overlap = false

--- a/gameplay/Backpack.gd
+++ b/gameplay/Backpack.gd
@@ -1,0 +1,24 @@
+extends Node2D
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	set_position(Vector2(20, 20))
+	# Transform.Position.x = 20
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass
+
+#func set_snapped_position(vector2):
+#	if not near_anchor:
+#		set_position(vector2)
+#		return
+#
+#	set_position(vector2)
+
+func snap_position_to_column(gameplay_column):
+	var anchor_point = gameplay_column.get_anchor_point()
+	set_position(anchor_point)

--- a/gameplay/Backpack.gd
+++ b/gameplay/Backpack.gd
@@ -1,6 +1,11 @@
 extends Area2D
 
-var is_mouse_overlap = false
+signal released
+
+var mouse_overlap = false
+var selected = false
+
+var _frame_rate = 25
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
@@ -11,7 +16,12 @@ func _ready():
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
-	pass
+	if selected:
+		global_position = lerp(
+			global_position,
+			get_global_mouse_position(),
+			_frame_rate * delta
+		)
 
 #func set_snapped_position(vector2):
 #	if not near_anchor:
@@ -24,8 +34,20 @@ func snap_position_to_column(gameplay_column):
 	var anchor_point = gameplay_column.get_anchor_point()
 	set_position(anchor_point)
 
+func _input(event):
+	if not Input.is_action_just_pressed("click"):
+		return
+
+	if selected:
+		released.emit()
+		selected = false
+		return
+
+	if mouse_overlap:
+		selected = true
+
 func _on_mouse_entered():
-	is_mouse_overlap = true
+	mouse_overlap = true
 
 func _on_mouse_exited():
-	is_mouse_overlap = false
+	mouse_overlap = false

--- a/gameplay/Backpack.gd
+++ b/gameplay/Backpack.gd
@@ -8,14 +8,6 @@ var selected = false
 
 var _frame_rate = 25
 
-# Called when the node enters the scene tree for the first time.
-func _ready():
-	set_position(Vector2(20, 20))
-	# Transform.Position.x = 20
-	pass # Replace with function body.
-
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
 	if selected:
 		global_position = lerp(
@@ -23,13 +15,6 @@ func _process(delta):
 			get_global_mouse_position(),
 			_frame_rate * delta
 		)
-
-#func set_snapped_position(vector2):
-#	if not near_anchor:
-#		set_position(vector2)
-#		return
-#
-#	set_position(vector2)
 
 func snap_position_to_column(gameplay_column):
 	var anchor_point = gameplay_column.get_anchor_point()

--- a/gameplay/Backpack.tscn
+++ b/gameplay/Backpack.tscn
@@ -1,0 +1,8 @@
+[gd_scene load_steps=2 format=3 uid="uid://24e0kif4kkdt"]
+
+[ext_resource type="Texture2D" uid="uid://brf4h74py8sal" path="res://icon.svg" id="1_hbr8j"]
+
+[node name="Backpack" type="Node2D"]
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+texture = ExtResource("1_hbr8j")

--- a/gameplay/Backpack.tscn
+++ b/gameplay/Backpack.tscn
@@ -1,10 +1,20 @@
-[gd_scene load_steps=3 format=3 uid="uid://24e0kif4kkdt"]
+[gd_scene load_steps=4 format=3 uid="uid://24e0kif4kkdt"]
 
 [ext_resource type="Script" path="res://gameplay/Backpack.gd" id="1_1wqex"]
 [ext_resource type="Texture2D" uid="uid://brf4h74py8sal" path="res://icon.svg" id="1_hbr8j"]
 
-[node name="Backpack" type="Node2D"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_2k672"]
+size = Vector2(128, 128)
+
+[node name="Backpack" type="Area2D"]
 script = ExtResource("1_1wqex")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource("RectangleShape2D_2k672")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 texture = ExtResource("1_hbr8j")
+
+[connection signal="input_event" from="." to="." method="_on_input_event"]
+[connection signal="mouse_entered" from="." to="." method="_on_mouse_entered"]
+[connection signal="mouse_exited" from="." to="." method="_on_mouse_exited"]

--- a/gameplay/Backpack.tscn
+++ b/gameplay/Backpack.tscn
@@ -1,8 +1,10 @@
-[gd_scene load_steps=2 format=3 uid="uid://24e0kif4kkdt"]
+[gd_scene load_steps=3 format=3 uid="uid://24e0kif4kkdt"]
 
+[ext_resource type="Script" path="res://gameplay/Backpack.gd" id="1_1wqex"]
 [ext_resource type="Texture2D" uid="uid://brf4h74py8sal" path="res://icon.svg" id="1_hbr8j"]
 
 [node name="Backpack" type="Node2D"]
+script = ExtResource("1_1wqex")
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 texture = ExtResource("1_hbr8j")

--- a/gameplay/Gameplay.gd
+++ b/gameplay/Gameplay.gd
@@ -6,28 +6,13 @@ extends Control
 var mock_goal = 4
 var mock_victory = false
 
-var _backpack_initialized = false
-var _columns_ready_count = 0
-var _expected_columns_initialized_count = 3
-
 func _ready():
 	database.reset_values()
 	_set_mock_goal()
 
-func _process(delta):
-	if (_are_columns_rendered()):
-		_backpack_initialized = true
-		$Backpack.snap_position_to_column($Columns/GameplayColumn)
-		$Backpack.visible = true
-		
-func _are_columns_rendered():
-	return (
-		not _backpack_initialized
-		and _columns_ready_count == _expected_columns_initialized_count
-	)
-
-func _increment_columns_ready_count():
-	_columns_ready_count += 1
+func _on_columns_sort_children():
+	$Backpack.snap_position_to_column($Columns/GameplayColumn)
+	$Backpack.visible = true
 
 func _increment_number_of_days():
 	database.increment_day_count()
@@ -36,15 +21,6 @@ func _increment_number_of_days():
 		get_tree().change_scene_to_file(
 			"res://gameplay/game_finished/GameFinished.tscn"
 		)
-
-func _on_gameplay_column_ready():
-	_increment_columns_ready_count()
-
-func _on_gameplay_column_2_ready():
-	_increment_columns_ready_count()
-
-func _on_gameplay_column_3_ready():
-	_increment_columns_ready_count()
 
 func _on_next_day_button_pressed():
 	_increment_number_of_days()
@@ -58,3 +34,20 @@ func _set_mock_goal():
 		str(mock_goal) +
 		" to win!"
 	)
+
+# Temp Code to let us experiment with adding / hiding columns
+func _input(event):
+	if event.is_action_pressed("ui_up"):
+		for column in $Columns.get_children():
+			if column.visible == false:
+				column.visible = true
+				return
+	
+	if event.is_action_pressed("ui_down"):
+		var reversed_column = $Columns.get_children()
+		reversed_column.reverse()
+		for column in reversed_column:
+			if column.visible == true:
+				column.visible = false
+				return
+

--- a/gameplay/Gameplay.gd
+++ b/gameplay/Gameplay.gd
@@ -6,7 +6,6 @@ extends Control
 var mock_goal = 4
 var mock_victory = false
 
-# Called when the node enters the scene tree for the first time.
 func _ready():
 	database.reset_values()
 	_set_mock_goal()

--- a/gameplay/Gameplay.gd
+++ b/gameplay/Gameplay.gd
@@ -11,10 +11,6 @@ func _ready():
 	database.reset_values()
 	_set_mock_goal()
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
-	pass
-
 func _increment_number_of_days():
 	database.increment_day_count()
 

--- a/gameplay/Gameplay.gd
+++ b/gameplay/Gameplay.gd
@@ -15,14 +15,19 @@ func _ready():
 	_set_mock_goal()
 
 func _process(delta):
-	if (
-		not _backpack_initialized
-		and _columns_ready_count == _expected_columns_initialized_count
-	):
+	if (_are_columns_rendered()):
 		_backpack_initialized = true
 		$Backpack.snap_position_to_column($Columns/GameplayColumn)
 		$Backpack.visible = true
 		
+func _are_columns_rendered():
+	return (
+		not _backpack_initialized
+		and _columns_ready_count == _expected_columns_initialized_count
+	)
+
+func _increment_columns_ready_count():
+	_columns_ready_count += 1
 
 func _increment_number_of_days():
 	database.increment_day_count()
@@ -31,6 +36,15 @@ func _increment_number_of_days():
 		get_tree().change_scene_to_file(
 			"res://gameplay/game_finished/GameFinished.tscn"
 		)
+
+func _on_gameplay_column_ready():
+	_increment_columns_ready_count()
+
+func _on_gameplay_column_2_ready():
+	_increment_columns_ready_count()
+
+func _on_gameplay_column_3_ready():
+	_increment_columns_ready_count()
 
 func _on_next_day_button_pressed():
 	_increment_number_of_days()
@@ -44,12 +58,3 @@ func _set_mock_goal():
 		str(mock_goal) +
 		" to win!"
 	)
-
-func _on_gameplay_column_ready():
-	_columns_ready_count += 1
-
-func _on_gameplay_column_2_ready():
-	_columns_ready_count += 1
-
-func _on_gameplay_column_3_ready():
-	_columns_ready_count += 1

--- a/gameplay/Gameplay.gd
+++ b/gameplay/Gameplay.gd
@@ -11,6 +11,12 @@ func _ready():
 	database.reset_values()
 	_set_mock_goal()
 
+func _label_columns():
+	for i in $Columns.get_child_count():
+		var shown_index = i + 1
+		var column = $Columns.get_child(i)
+		column.set_column_header_index(shown_index)
+
 func _increment_number_of_days():
 	database.increment_day_count()
 

--- a/gameplay/Gameplay.gd
+++ b/gameplay/Gameplay.gd
@@ -11,12 +11,6 @@ func _ready():
 	database.reset_values()
 	_set_mock_goal()
 
-func _label_columns():
-	for i in $Columns.get_child_count():
-		var shown_index = i + 1
-		var column = $Columns.get_child(i)
-		column.set_column_header_index(shown_index)
-
 func _increment_number_of_days():
 	database.increment_day_count()
 

--- a/gameplay/Gameplay.gd
+++ b/gameplay/Gameplay.gd
@@ -10,6 +10,7 @@ var mock_victory = false
 func _ready():
 	database.reset_values()
 	_set_mock_goal()
+	$Backpack.snap_position_to_column($Columns/GameplayColumn)
 
 func _increment_number_of_days():
 	database.increment_day_count()

--- a/gameplay/Gameplay.gd
+++ b/gameplay/Gameplay.gd
@@ -6,12 +6,23 @@ extends Control
 var mock_goal = 4
 var mock_victory = false
 
+var _backpack_initialized = false
+var _columns_ready_count = 0
+var _expected_columns_initialized_count = 3
+
 func _ready():
 	database.reset_values()
 	_set_mock_goal()
 
-func _process(_delta):
-	$Backpack.snap_position_to_column($Columns/GameplayColumn)
+func _process(delta):
+	if (
+		not _backpack_initialized
+		and _columns_ready_count == _expected_columns_initialized_count
+	):
+		_backpack_initialized = true
+		$Backpack.snap_position_to_column($Columns/GameplayColumn)
+		$Backpack.visible = true
+		
 
 func _increment_number_of_days():
 	database.increment_day_count()
@@ -33,3 +44,12 @@ func _set_mock_goal():
 		str(mock_goal) +
 		" to win!"
 	)
+
+func _on_gameplay_column_ready():
+	_columns_ready_count += 1
+
+func _on_gameplay_column_2_ready():
+	_columns_ready_count += 1
+
+func _on_gameplay_column_3_ready():
+	_columns_ready_count += 1

--- a/gameplay/Gameplay.gd
+++ b/gameplay/Gameplay.gd
@@ -10,6 +10,8 @@ var mock_victory = false
 func _ready():
 	database.reset_values()
 	_set_mock_goal()
+
+func _process(_delta):
 	$Backpack.snap_position_to_column($Columns/GameplayColumn)
 
 func _increment_number_of_days():

--- a/gameplay/Gameplay.gd
+++ b/gameplay/Gameplay.gd
@@ -10,6 +10,20 @@ func _ready():
 	database.reset_values()
 	_set_mock_goal()
 
+func _attempt_to_hide_last_column():
+	var reversed_columns = $Columns.get_children()
+	reversed_columns.reverse()
+	for column in reversed_columns:
+		if column.visible:
+			column.visible = false
+			return
+
+func _attempt_to_reveal_next_column():
+	for column in $Columns.get_children():
+		if not column.visible:
+			column.visible = true
+			return
+
 func _on_columns_sort_children():
 	$Backpack.snap_position_to_column($Columns/GameplayColumn)
 	$Backpack.visible = true
@@ -38,16 +52,9 @@ func _set_mock_goal():
 # Temp Code to let us experiment with adding / hiding columns
 func _input(event):
 	if event.is_action_pressed("ui_up"):
-		for column in $Columns.get_children():
-			if column.visible == false:
-				column.visible = true
-				return
-	
-	if event.is_action_pressed("ui_down"):
-		var reversed_column = $Columns.get_children()
-		reversed_column.reverse()
-		for column in reversed_column:
-			if column.visible == true:
-				column.visible = false
-				return
+		_attempt_to_reveal_next_column()
+		return
 
+	if event.is_action_pressed("ui_down"):
+		_attempt_to_hide_last_column()
+		return

--- a/gameplay/Gameplay.tscn
+++ b/gameplay/Gameplay.tscn
@@ -2,10 +2,10 @@
 
 [ext_resource type="Script" path="res://gameplay/Gameplay.gd" id="1_cv37s"]
 [ext_resource type="PackedScene" uid="uid://c25adoveil6xs" path="res://hud/CurrencySilverCoin.tscn" id="2_a1m00"]
-[ext_resource type="FontFile" uid="uid://cddebactj84w3" path="res://fonts/Roboto/Roboto-Medium.ttf" id="2_ny8ex"]
+[ext_resource type="FontFile" uid="uid://d1faal3mxcb84" path="res://fonts/Roboto/Roboto-Medium.ttf" id="2_ny8ex"]
 [ext_resource type="PackedScene" uid="uid://dm07s06ryg2u" path="res://menus/BackToStartMenuButton.tscn" id="3_7t8p6"]
 [ext_resource type="Script" path="res://gameplay/NextDayButton.gd" id="4_fxq41"]
-[ext_resource type="FontFile" uid="uid://c104v5f0ficln" path="res://fonts/Roboto/Roboto-Regular.ttf" id="5_rf4ff"]
+[ext_resource type="FontFile" uid="uid://b0t1dk3g11t5r" path="res://fonts/Roboto/Roboto-Regular.ttf" id="5_rf4ff"]
 [ext_resource type="PackedScene" uid="uid://e1hatl7xepnb" path="res://hud/DaysPassedTracker.tscn" id="7_6ilhd"]
 [ext_resource type="PackedScene" uid="uid://dklr5kcqww66r" path="res://gameplay/GameplayColumn.tscn" id="8_pe5uu"]
 [ext_resource type="PackedScene" uid="uid://24e0kif4kkdt" path="res://gameplay/Backpack.tscn" id="9_6n0cn"]
@@ -122,6 +122,4 @@ visible = false
 
 [connection signal="timeout" from="MockExplanation/DelayHidingTitle" to="." method="_on_timer_timeout"]
 [connection signal="pressed" from="NextDay/NextDayButton" to="." method="_on_next_day_button_pressed"]
-[connection signal="ready" from="Columns/GameplayColumn" to="." method="_on_gameplay_column_ready"]
-[connection signal="ready" from="Columns/GameplayColumn2" to="." method="_on_gameplay_column_2_ready"]
-[connection signal="ready" from="Columns/GameplayColumn3" to="." method="_on_gameplay_column_3_ready"]
+[connection signal="sort_children" from="Columns" to="." method="_on_columns_sort_children"]

--- a/gameplay/Gameplay.tscn
+++ b/gameplay/Gameplay.tscn
@@ -118,6 +118,10 @@ visible = false
 layout_mode = 2
 
 [node name="Backpack" parent="." instance=ExtResource("9_6n0cn")]
+visible = false
 
 [connection signal="timeout" from="MockExplanation/DelayHidingTitle" to="." method="_on_timer_timeout"]
 [connection signal="pressed" from="NextDay/NextDayButton" to="." method="_on_next_day_button_pressed"]
+[connection signal="ready" from="Columns/GameplayColumn" to="." method="_on_gameplay_column_ready"]
+[connection signal="ready" from="Columns/GameplayColumn2" to="." method="_on_gameplay_column_2_ready"]
+[connection signal="ready" from="Columns/GameplayColumn3" to="." method="_on_gameplay_column_3_ready"]

--- a/gameplay/Gameplay.tscn
+++ b/gameplay/Gameplay.tscn
@@ -2,10 +2,10 @@
 
 [ext_resource type="Script" path="res://gameplay/Gameplay.gd" id="1_cv37s"]
 [ext_resource type="PackedScene" uid="uid://c25adoveil6xs" path="res://hud/CurrencySilverCoin.tscn" id="2_a1m00"]
-[ext_resource type="FontFile" uid="uid://d1faal3mxcb84" path="res://fonts/Roboto/Roboto-Medium.ttf" id="2_ny8ex"]
+[ext_resource type="FontFile" uid="uid://cddebactj84w3" path="res://fonts/Roboto/Roboto-Medium.ttf" id="2_ny8ex"]
 [ext_resource type="PackedScene" uid="uid://dm07s06ryg2u" path="res://menus/BackToStartMenuButton.tscn" id="3_7t8p6"]
 [ext_resource type="Script" path="res://gameplay/NextDayButton.gd" id="4_fxq41"]
-[ext_resource type="FontFile" uid="uid://b0t1dk3g11t5r" path="res://fonts/Roboto/Roboto-Regular.ttf" id="5_rf4ff"]
+[ext_resource type="FontFile" uid="uid://c104v5f0ficln" path="res://fonts/Roboto/Roboto-Regular.ttf" id="5_rf4ff"]
 [ext_resource type="PackedScene" uid="uid://e1hatl7xepnb" path="res://hud/DaysPassedTracker.tscn" id="7_6ilhd"]
 [ext_resource type="PackedScene" uid="uid://dklr5kcqww66r" path="res://gameplay/GameplayColumn.tscn" id="8_pe5uu"]
 [ext_resource type="PackedScene" uid="uid://24e0kif4kkdt" path="res://gameplay/Backpack.tscn" id="9_6n0cn"]

--- a/gameplay/Gameplay.tscn
+++ b/gameplay/Gameplay.tscn
@@ -1,12 +1,13 @@
-[gd_scene load_steps=8 format=3 uid="uid://crk2s578wsl64"]
+[gd_scene load_steps=9 format=3 uid="uid://crk2s578wsl64"]
 
 [ext_resource type="Script" path="res://gameplay/Gameplay.gd" id="1_cv37s"]
 [ext_resource type="PackedScene" uid="uid://c25adoveil6xs" path="res://hud/CurrencySilverCoin.tscn" id="2_a1m00"]
-[ext_resource type="FontFile" uid="uid://d4hul02h7mc5f" path="res://fonts/Roboto/Roboto-Medium.ttf" id="2_ny8ex"]
+[ext_resource type="FontFile" uid="uid://cddebactj84w3" path="res://fonts/Roboto/Roboto-Medium.ttf" id="2_ny8ex"]
 [ext_resource type="PackedScene" uid="uid://dm07s06ryg2u" path="res://menus/BackToStartMenuButton.tscn" id="3_7t8p6"]
 [ext_resource type="Script" path="res://gameplay/NextDayButton.gd" id="4_fxq41"]
-[ext_resource type="FontFile" uid="uid://bfaytobi4bbyw" path="res://fonts/Roboto/Roboto-Regular.ttf" id="5_rf4ff"]
+[ext_resource type="FontFile" uid="uid://c104v5f0ficln" path="res://fonts/Roboto/Roboto-Regular.ttf" id="5_rf4ff"]
 [ext_resource type="PackedScene" uid="uid://e1hatl7xepnb" path="res://hud/DaysPassedTracker.tscn" id="7_6ilhd"]
+[ext_resource type="PackedScene" uid="uid://dklr5kcqww66r" path="res://gameplay/GameplayColumn.tscn" id="8_pe5uu"]
 
 [node name="Gameplay" type="Control"]
 layout_mode = 3
@@ -77,6 +78,39 @@ theme_override_fonts/font = ExtResource("2_ny8ex")
 theme_override_font_sizes/font_size = 18
 text = "Next Day"
 script = ExtResource("4_fxq41")
+
+[node name="Columns" type="HBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -409.0
+offset_top = -200.0
+offset_right = 409.0
+offset_bottom = 200.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 10
+
+[node name="GameplayColumn" parent="Columns" instance=ExtResource("8_pe5uu")]
+layout_mode = 2
+
+[node name="GameplayColumn2" parent="Columns" instance=ExtResource("8_pe5uu")]
+layout_mode = 2
+
+[node name="GameplayColumn3" parent="Columns" instance=ExtResource("8_pe5uu")]
+layout_mode = 2
+
+[node name="GameplayColumn4" parent="Columns" instance=ExtResource("8_pe5uu")]
+layout_mode = 2
+
+[node name="GameplayColumn5" parent="Columns" instance=ExtResource("8_pe5uu")]
+layout_mode = 2
+
+[node name="GameplayColumn6" parent="Columns" instance=ExtResource("8_pe5uu")]
+layout_mode = 2
 
 [connection signal="timeout" from="MockExplanation/DelayHidingTitle" to="." method="_on_timer_timeout"]
 [connection signal="pressed" from="NextDay/NextDayButton" to="." method="_on_next_day_button_pressed"]

--- a/gameplay/Gameplay.tscn
+++ b/gameplay/Gameplay.tscn
@@ -94,6 +94,7 @@ offset_bottom = 200.0
 grow_horizontal = 2
 grow_vertical = 2
 theme_override_constants/separation = 10
+alignment = 1
 
 [node name="GameplayColumn" parent="Columns" instance=ExtResource("8_pe5uu")]
 layout_mode = 2
@@ -105,12 +106,15 @@ layout_mode = 2
 layout_mode = 2
 
 [node name="GameplayColumn4" parent="Columns" instance=ExtResource("8_pe5uu")]
+visible = false
 layout_mode = 2
 
 [node name="GameplayColumn5" parent="Columns" instance=ExtResource("8_pe5uu")]
+visible = false
 layout_mode = 2
 
 [node name="GameplayColumn6" parent="Columns" instance=ExtResource("8_pe5uu")]
+visible = false
 layout_mode = 2
 
 [node name="Backpack" parent="." instance=ExtResource("9_6n0cn")]

--- a/gameplay/Gameplay.tscn
+++ b/gameplay/Gameplay.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=9 format=3 uid="uid://crk2s578wsl64"]
+[gd_scene load_steps=10 format=3 uid="uid://crk2s578wsl64"]
 
 [ext_resource type="Script" path="res://gameplay/Gameplay.gd" id="1_cv37s"]
 [ext_resource type="PackedScene" uid="uid://c25adoveil6xs" path="res://hud/CurrencySilverCoin.tscn" id="2_a1m00"]
@@ -8,6 +8,7 @@
 [ext_resource type="FontFile" uid="uid://c104v5f0ficln" path="res://fonts/Roboto/Roboto-Regular.ttf" id="5_rf4ff"]
 [ext_resource type="PackedScene" uid="uid://e1hatl7xepnb" path="res://hud/DaysPassedTracker.tscn" id="7_6ilhd"]
 [ext_resource type="PackedScene" uid="uid://dklr5kcqww66r" path="res://gameplay/GameplayColumn.tscn" id="8_pe5uu"]
+[ext_resource type="PackedScene" uid="uid://24e0kif4kkdt" path="res://gameplay/Backpack.tscn" id="9_6n0cn"]
 
 [node name="Gameplay" type="Control"]
 layout_mode = 3
@@ -111,6 +112,8 @@ layout_mode = 2
 
 [node name="GameplayColumn6" parent="Columns" instance=ExtResource("8_pe5uu")]
 layout_mode = 2
+
+[node name="Backpack" parent="." instance=ExtResource("9_6n0cn")]
 
 [connection signal="timeout" from="MockExplanation/DelayHidingTitle" to="." method="_on_timer_timeout"]
 [connection signal="pressed" from="NextDay/NextDayButton" to="." method="_on_next_day_button_pressed"]

--- a/gameplay/GameplayColumn.gd
+++ b/gameplay/GameplayColumn.gd
@@ -1,0 +1,10 @@
+extends Control
+
+var column_index = 1
+
+func _ready():
+	$Header/ColumnNumber.text = str(column_index)
+
+func set_column_header_index(index):
+	column_index = index
+	$Header/ColumnNumber.text = str(column_index)

--- a/gameplay/GameplayColumn.gd
+++ b/gameplay/GameplayColumn.gd
@@ -4,3 +4,6 @@ var column_index = 1
 
 func _ready():
 	pass
+
+func get_anchor_point():
+	return $AnchorPoint.position

--- a/gameplay/GameplayColumn.gd
+++ b/gameplay/GameplayColumn.gd
@@ -6,4 +6,4 @@ func _ready():
 	pass
 
 func get_anchor_point():
-	return $AnchorPoint.position
+	return $AnchorPoint.global_position

--- a/gameplay/GameplayColumn.gd
+++ b/gameplay/GameplayColumn.gd
@@ -1,3 +1,4 @@
+# Column to reserve space for a region or a customer.
 extends Control
 
 var column_index = 1

--- a/gameplay/GameplayColumn.gd
+++ b/gameplay/GameplayColumn.gd
@@ -3,8 +3,4 @@ extends Control
 var column_index = 1
 
 func _ready():
-	$Header/ColumnNumber.text = str(column_index)
-
-func set_column_header_index(index):
-	column_index = index
-	$Header/ColumnNumber.text = str(column_index)
+	pass

--- a/gameplay/GameplayColumn.tscn
+++ b/gameplay/GameplayColumn.tscn
@@ -21,5 +21,12 @@ grow_horizontal = 2
 grow_vertical = 2
 color = Color(0.686275, 0.686275, 0.686275, 1)
 
-[node name="AnchorPoint" type="Node2D" parent="."]
-position = Vector2(563, 610)
+[node name="AnchorPoint" type="Control" parent="."]
+layout_mode = 1
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 0

--- a/gameplay/GameplayColumn.tscn
+++ b/gameplay/GameplayColumn.tscn
@@ -1,0 +1,45 @@
+[gd_scene load_steps=3 format=3 uid="uid://dklr5kcqww66r"]
+
+[ext_resource type="Script" path="res://gameplay/GameplayColumn.gd" id="1_n2apv"]
+[ext_resource type="FontFile" uid="uid://c104v5f0ficln" path="res://fonts/Roboto/Roboto-Regular.ttf" id="1_o7pca"]
+
+[node name="GameplayColumn" type="Control"]
+custom_minimum_size = Vector2(128, 400)
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_n2apv")
+
+[node name="BackgroundFill" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.686275, 0.686275, 0.686275, 1)
+
+[node name="Header" type="HBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -34.5
+offset_right = 34.5
+offset_bottom = 22.0
+grow_horizontal = 2
+
+[node name="ColumnUnit" type="Label" parent="Header"]
+layout_mode = 2
+theme_override_fonts/font = ExtResource("1_o7pca")
+theme_override_font_sizes/font_size = 24
+text = "Column"
+
+[node name="ColumnNumber" type="Label" parent="Header"]
+layout_mode = 2
+theme_override_fonts/font = ExtResource("1_o7pca")
+theme_override_font_sizes/font_size = 24
+text = "1"

--- a/gameplay/GameplayColumn.tscn
+++ b/gameplay/GameplayColumn.tscn
@@ -20,3 +20,5 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 color = Color(0.686275, 0.686275, 0.686275, 1)
+
+[node name="AnchorPoint" type="Node2D" parent="."]

--- a/gameplay/GameplayColumn.tscn
+++ b/gameplay/GameplayColumn.tscn
@@ -1,7 +1,6 @@
-[gd_scene load_steps=3 format=3 uid="uid://dklr5kcqww66r"]
+[gd_scene load_steps=2 format=3 uid="uid://dklr5kcqww66r"]
 
 [ext_resource type="Script" path="res://gameplay/GameplayColumn.gd" id="1_n2apv"]
-[ext_resource type="FontFile" uid="uid://c104v5f0ficln" path="res://fonts/Roboto/Roboto-Regular.ttf" id="1_o7pca"]
 
 [node name="GameplayColumn" type="Control"]
 custom_minimum_size = Vector2(128, 400)
@@ -21,25 +20,3 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 color = Color(0.686275, 0.686275, 0.686275, 1)
-
-[node name="Header" type="HBoxContainer" parent="."]
-layout_mode = 1
-anchors_preset = 5
-anchor_left = 0.5
-anchor_right = 0.5
-offset_left = -34.5
-offset_right = 34.5
-offset_bottom = 22.0
-grow_horizontal = 2
-
-[node name="ColumnUnit" type="Label" parent="Header"]
-layout_mode = 2
-theme_override_fonts/font = ExtResource("1_o7pca")
-theme_override_font_sizes/font_size = 24
-text = "Column"
-
-[node name="ColumnNumber" type="Label" parent="Header"]
-layout_mode = 2
-theme_override_fonts/font = ExtResource("1_o7pca")
-theme_override_font_sizes/font_size = 24
-text = "1"

--- a/gameplay/GameplayColumn.tscn
+++ b/gameplay/GameplayColumn.tscn
@@ -22,3 +22,4 @@ grow_vertical = 2
 color = Color(0.686275, 0.686275, 0.686275, 1)
 
 [node name="AnchorPoint" type="Node2D" parent="."]
+position = Vector2(563, 610)

--- a/hud/CurrencySilverCoin.gd
+++ b/hud/CurrencySilverCoin.gd
@@ -7,10 +7,6 @@ func _ready():
 	_sync_silver_coin_count()
 	database.connect("updated_silver_coin_count", _on_updated_silver_coin_count)
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
-	pass
-
 func _on_updated_silver_coin_count():
 	$Amount.text = str(database.silver_coin_count)
 

--- a/hud/DaysPassedTracker.gd
+++ b/hud/DaysPassedTracker.gd
@@ -7,10 +7,6 @@ func _ready():
 	_sync_day_count()
 	database.connect("updated_day_count", _on_updated_day_count)
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
-	pass
-
 func _on_updated_day_count():
 	_sync_day_count()
 

--- a/project.godot
+++ b/project.godot
@@ -19,6 +19,14 @@ config/icon="res://icon.svg"
 
 Database="*res://data/database.gd"
 
+[input]
+
+click={
+"deadzone": 0.5,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
+}
+
 [rendering]
 
 renderer/rendering_method="gl_compatibility"


### PR DESCRIPTION
Partially implement draft 2 by adding blank columns, and a draggable backpack which starts at the bottom of the first column.

The backpack uses a placeholder icon, and looks 20% larger while selected for fake-tactile user feedback.

## Screenshots

![pr-2_columns-and-backpack](https://github.com/SamBumgardner/packrat-game/assets/11843918/cb831dab-c297-437c-ba4a-00e665645870)
_**Screenshot 1:** Local screenshot after waiting at least 3 seconds on the gameplay screen._

![pr-2_enlarge](https://github.com/SamBumgardner/packrat-game/assets/11843918/2d70c32c-681c-46ad-b65f-b40c5fe1c7b4)
_**Screenshot 2:** Local screenshot while the backpack is selected._