### PR TITLE
simplify check for when columns load

### DIFF
--- a/gameplay/Gameplay.gd
+++ b/gameplay/Gameplay.gd
@@ -6,28 +6,13 @@ extends Control
 var mock_goal = 4
 var mock_victory = false
 
-var _backpack_initialized = false
-var _columns_ready_count = 0
-var _expected_columns_initialized_count = 3
-
 func _ready():
 	database.reset_values()
 	_set_mock_goal()
 
-func _process(delta):
-	if (_are_columns_rendered()):
-		_backpack_initialized = true
-		$Backpack.snap_position_to_column($Columns/GameplayColumn)
-		$Backpack.visible = true
-		
-func _are_columns_rendered():
-	return (
-		not _backpack_initialized
-		and _columns_ready_count == _expected_columns_initialized_count
-	)
-
-func _increment_columns_ready_count():
-	_columns_ready_count += 1
+func _on_columns_sort_children():
+	$Backpack.snap_position_to_column($Columns/GameplayColumn)
+	$Backpack.visible = true
 
 func _increment_number_of_days():
 	database.increment_day_count()
@@ -36,15 +21,6 @@ func _increment_number_of_days():
 		get_tree().change_scene_to_file(
 			"res://gameplay/game_finished/GameFinished.tscn"
 		)
-
-func _on_gameplay_column_ready():
-	_increment_columns_ready_count()
-
-func _on_gameplay_column_2_ready():
-	_increment_columns_ready_count()
-
-func _on_gameplay_column_3_ready():
-	_increment_columns_ready_count()
 
 func _on_next_day_button_pressed():
 	_increment_number_of_days()
@@ -58,3 +34,20 @@ func _set_mock_goal():
 		str(mock_goal) +
 		" to win!"
 	)
+
+# Temp Code to let us experiment with adding / hiding columns
+func _input(event):
+	if event.is_action_pressed("ui_up"):
+		for column in $Columns.get_children():
+			if column.visible == false:
+				column.visible = true
+				return
+	
+	if event.is_action_pressed("ui_down"):
+		var reversed_column = $Columns.get_children()
+		reversed_column.reverse()
+		for column in reversed_column:
+			if column.visible == true:
+				column.visible = false
+				return
+

--- a/gameplay/Gameplay.gd
+++ b/gameplay/Gameplay.gd
@@ -10,6 +10,20 @@ func _ready():
 	database.reset_values()
 	_set_mock_goal()
 
+func _attempt_to_hide_last_column():
+	var reversed_columns = $Columns.get_children()
+	reversed_columns.reverse()
+	for column in reversed_columns:
+		if column.visible:
+			column.visible = false
+			return
+
+func _attempt_to_reveal_next_column():
+	for column in $Columns.get_children():
+		if not column.visible:
+			column.visible = true
+			return
+
 func _on_columns_sort_children():
 	$Backpack.snap_position_to_column($Columns/GameplayColumn)
 	$Backpack.visible = true
@@ -38,16 +52,9 @@ func _set_mock_goal():
 # Temp Code to let us experiment with adding / hiding columns
 func _input(event):
 	if event.is_action_pressed("ui_up"):
-		for column in $Columns.get_children():
-			if column.visible == false:
-				column.visible = true
-				return
-	
-	if event.is_action_pressed("ui_down"):
-		var reversed_column = $Columns.get_children()
-		reversed_column.reverse()
-		for column in reversed_column:
-			if column.visible == true:
-				column.visible = false
-				return
+		_attempt_to_reveal_next_column()
+		return
 
+	if event.is_action_pressed("ui_down"):
+		_attempt_to_hide_last_column()
+		return

--- a/gameplay/Gameplay.tscn
+++ b/gameplay/Gameplay.tscn
@@ -2,10 +2,10 @@
 
 [ext_resource type="Script" path="res://gameplay/Gameplay.gd" id="1_cv37s"]
 [ext_resource type="PackedScene" uid="uid://c25adoveil6xs" path="res://hud/CurrencySilverCoin.tscn" id="2_a1m00"]
-[ext_resource type="FontFile" uid="uid://cddebactj84w3" path="res://fonts/Roboto/Roboto-Medium.ttf" id="2_ny8ex"]
+[ext_resource type="FontFile" uid="uid://d1faal3mxcb84" path="res://fonts/Roboto/Roboto-Medium.ttf" id="2_ny8ex"]
 [ext_resource type="PackedScene" uid="uid://dm07s06ryg2u" path="res://menus/BackToStartMenuButton.tscn" id="3_7t8p6"]
 [ext_resource type="Script" path="res://gameplay/NextDayButton.gd" id="4_fxq41"]
-[ext_resource type="FontFile" uid="uid://c104v5f0ficln" path="res://fonts/Roboto/Roboto-Regular.ttf" id="5_rf4ff"]
+[ext_resource type="FontFile" uid="uid://b0t1dk3g11t5r" path="res://fonts/Roboto/Roboto-Regular.ttf" id="5_rf4ff"]
 [ext_resource type="PackedScene" uid="uid://e1hatl7xepnb" path="res://hud/DaysPassedTracker.tscn" id="7_6ilhd"]
 [ext_resource type="PackedScene" uid="uid://dklr5kcqww66r" path="res://gameplay/GameplayColumn.tscn" id="8_pe5uu"]
 [ext_resource type="PackedScene" uid="uid://24e0kif4kkdt" path="res://gameplay/Backpack.tscn" id="9_6n0cn"]
@@ -122,6 +122,4 @@ visible = false
 
 [connection signal="timeout" from="MockExplanation/DelayHidingTitle" to="." method="_on_timer_timeout"]
 [connection signal="pressed" from="NextDay/NextDayButton" to="." method="_on_next_day_button_pressed"]
-[connection signal="ready" from="Columns/GameplayColumn" to="." method="_on_gameplay_column_ready"]
-[connection signal="ready" from="Columns/GameplayColumn2" to="." method="_on_gameplay_column_2_ready"]
-[connection signal="ready" from="Columns/GameplayColumn3" to="." method="_on_gameplay_column_3_ready"]
+[connection signal="sort_children" from="Columns" to="." method="_on_columns_sort_children"]

--- a/gameplay/Gameplay.tscn
+++ b/gameplay/Gameplay.tscn
@@ -2,10 +2,10 @@
 
 [ext_resource type="Script" path="res://gameplay/Gameplay.gd" id="1_cv37s"]
 [ext_resource type="PackedScene" uid="uid://c25adoveil6xs" path="res://hud/CurrencySilverCoin.tscn" id="2_a1m00"]
-[ext_resource type="FontFile" uid="uid://d1faal3mxcb84" path="res://fonts/Roboto/Roboto-Medium.ttf" id="2_ny8ex"]
+[ext_resource type="FontFile" uid="uid://cddebactj84w3" path="res://fonts/Roboto/Roboto-Medium.ttf" id="2_ny8ex"]
 [ext_resource type="PackedScene" uid="uid://dm07s06ryg2u" path="res://menus/BackToStartMenuButton.tscn" id="3_7t8p6"]
 [ext_resource type="Script" path="res://gameplay/NextDayButton.gd" id="4_fxq41"]
-[ext_resource type="FontFile" uid="uid://b0t1dk3g11t5r" path="res://fonts/Roboto/Roboto-Regular.ttf" id="5_rf4ff"]
+[ext_resource type="FontFile" uid="uid://c104v5f0ficln" path="res://fonts/Roboto/Roboto-Regular.ttf" id="5_rf4ff"]
 [ext_resource type="PackedScene" uid="uid://e1hatl7xepnb" path="res://hud/DaysPassedTracker.tscn" id="7_6ilhd"]
 [ext_resource type="PackedScene" uid="uid://dklr5kcqww66r" path="res://gameplay/GameplayColumn.tscn" id="8_pe5uu"]
 [ext_resource type="PackedScene" uid="uid://24e0kif4kkdt" path="res://gameplay/Backpack.tscn" id="9_6n0cn"]


### PR DESCRIPTION
Previous code required each column to emit an event when they were positioned and owning script had to keep track of when each was completed.

Now we can just wait for the container wrapping the columns to report that everything inside of it has been sorted and resized. Will probably be useful in the future when we can add/subtract columns.