### PR TITLE
Backpack column interaction

### DIFF
--- a/gameplay/Backpack.gd
+++ b/gameplay/Backpack.gd
@@ -3,7 +3,8 @@ extends Area2D
 
 class_name Backpack
 
-signal released
+signal backpack_selected
+signal backpack_released
 
 var mouse_overlap = false
 var selected = false
@@ -25,7 +26,7 @@ func snap_position(new_position:Vector2):
 	# emit events, play sounds, wiggle backpack here.
 
 func _deselect_and_shrink_backpack():
-	released.emit()
+	backpack_released.emit()
 	selected = false
 	$Sprite2D.apply_scale(
 		Vector2(_scale_down_original, _scale_down_original)
@@ -53,3 +54,4 @@ func _select_and_enlarge_backpack():
 	$Sprite2D.apply_scale(
 		Vector2(_scale_up_20_percent, _scale_up_20_percent)
 	)
+	backpack_selected.emit(self)

--- a/gameplay/Backpack.gd
+++ b/gameplay/Backpack.gd
@@ -21,11 +21,20 @@ var _contained_items:Array[Item] = []
 @onready var collision_shape:Shape2D = $CollisionShape2D.shape
 @onready var shadow:Sprite2D = $ShadowSprite
 
+	###########
+	# GENERAL #
+	###########
 func _ready():
 	shadow.visible = false
 	_contained_elements.resize(GlobalConstants.Elements.size())
 	_contained_elements.fill(0)
 
+func get_shadow():
+	return shadow
+
+	#####################
+	# MOVEMENT HANDLING #
+	#####################
 func _process(delta):
 	if selected:
 		set_target_position(get_viewport().get_mouse_position())
@@ -49,12 +58,9 @@ func stop_movement():
 	_moving_to_target = false
 	_target_global_position = Vector2.ZERO
 
-func get_shadow():
-	return shadow
-
-	##################
-	# INPUT HANDLING #
-	##################
+	######################
+	# SELECTION HANDLING #
+	######################
 func _mouse_overlap_manual_check():
 	var manual_mouse_check_rect = Rect2(collision_shape.get_rect())
 	manual_mouse_check_rect.position += global_position
@@ -87,7 +93,6 @@ func stop_deselect_shrink_backpack():
 		Vector2(_scale_down_original, _scale_down_original)
 	)
 	_mouse_overlap_manual_check()
-	
 
 	#######################
 	# CONTENTS MANAGEMENT #
@@ -113,6 +118,3 @@ func add_item(item:Item):
 
 func change_capacity(new_capacity):
 	_item_capacity = new_capacity
-
-
-

--- a/gameplay/Backpack.gd
+++ b/gameplay/Backpack.gd
@@ -13,6 +13,15 @@ var _frame_rate = 25
 var _scale_down_original = 0.833333333333
 var _scale_up_20_percent = 1.2
 
+@export var _item_capacity = 2
+var _contained_elements:Array[int] = []
+var _contained_items:Array[Item] = []
+
+func _ready():
+	Object
+	_contained_elements.resize(GlobalConstants.Elements.size())
+	_contained_elements.fill(0)
+
 func _process(delta):
 	if selected:
 		global_position = lerp(
@@ -25,13 +34,9 @@ func snap_position(new_position:Vector2):
 	set_position(new_position)
 	# emit events, play sounds, wiggle backpack here.
 
-func _deselect_and_shrink_backpack():
-	backpack_released.emit()
-	selected = false
-	$Sprite2D.apply_scale(
-		Vector2(_scale_down_original, _scale_down_original)
-	)
-
+	##################
+	# INPUT HANDLING #
+	##################
 func _input(event):
 	if not Input.is_action_just_pressed("click"):
 		return
@@ -55,3 +60,38 @@ func _select_and_enlarge_backpack():
 		Vector2(_scale_up_20_percent, _scale_up_20_percent)
 	)
 	backpack_selected.emit(self)
+
+func _deselect_and_shrink_backpack():
+	backpack_released.emit()
+	selected = false
+	$Sprite2D.apply_scale(
+		Vector2(_scale_down_original, _scale_down_original)
+	)
+
+	#######################
+	# CONTENTS MANAGEMENT #
+	#######################
+func get_elements():
+	return _contained_elements.duplicate()
+
+func remove_items():
+	for i in _contained_elements.size():
+		_contained_elements[i] = 0
+	var removed_items = _contained_items.duplicate()
+	_contained_items.clear()
+	return removed_items
+
+func add_item(item:Item):
+	var added_item = false
+	if _contained_items.size() < _item_capacity:
+		_contained_elements.append(item)
+		for i in _contained_elements.size():
+			_contained_elements[i] += item.elements[i]
+		added_item = true
+	return added_item
+
+func change_capacity(new_capacity):
+	_item_capacity = new_capacity
+
+
+

--- a/gameplay/Backpack.gd
+++ b/gameplay/Backpack.gd
@@ -1,6 +1,8 @@
 # Backpack to drag underneath gameplay columns.
 extends Area2D
 
+class_name Backpack
+
 signal released
 
 var mouse_overlap = false
@@ -18,9 +20,9 @@ func _process(delta):
 			_frame_rate * delta
 		)
 
-func snap_position_to_column(gameplay_column):
-	var anchor_point = gameplay_column.get_anchor_point()
-	set_position(anchor_point)
+func snap_position(new_position:Vector2):
+	set_position(new_position)
+	# emit events, play sounds, wiggle backpack here.
 
 func _deselect_and_shrink_backpack():
 	released.emit()

--- a/gameplay/Backpack.gd
+++ b/gameplay/Backpack.gd
@@ -9,6 +9,8 @@ signal backpack_exited
 var selected = false
 
 var _frame_rate = 25
+var _moving_to_target = false
+var _target_global_position:Vector2 = Vector2.ZERO
 var _scale_down_original = 0.833333333333
 var _scale_up_20_percent = 1.2
 
@@ -24,11 +26,26 @@ func _ready():
 
 func _process(delta):
 	if selected:
+		set_target_position(get_viewport().get_mouse_position())
+	
+	draw_front(_moving_to_target)
+	if _moving_to_target:
 		global_position = lerp(
 			global_position,
-			get_global_mouse_position(),
+			_target_global_position,
 			_frame_rate * delta
 		)
+	
+	if global_position.is_equal_approx(_target_global_position):
+		stop_movement()
+
+func set_target_position(target:Vector2):
+	_target_global_position = target
+	_moving_to_target = true
+
+func stop_movement():
+	_moving_to_target = false
+	_target_global_position = Vector2.ZERO
 
 	##################
 	# INPUT HANDLING #
@@ -45,13 +62,19 @@ func _on_mouse_entered():
 func _on_mouse_exited():
 	backpack_exited.emit(self)
 
+func draw_front(in_front:bool):
+	var previous_position = global_position
+	top_level = in_front
+	global_position = previous_position
+
 func select_and_enlarge_backpack():
 	selected = true
 	$Sprite2D.apply_scale(
 		Vector2(_scale_up_20_percent, _scale_up_20_percent)
 	)
 
-func deselect_and_shrink_backpack():
+func stop_deselect_shrink_backpack():
+	stop_movement()
 	selected = false
 	$Sprite2D.apply_scale(
 		Vector2(_scale_down_original, _scale_down_original)

--- a/gameplay/Backpack.gd
+++ b/gameplay/Backpack.gd
@@ -19,8 +19,10 @@ var _contained_elements:Array[int] = []
 var _contained_items:Array[Item] = []
 
 @onready var collision_shape:Shape2D = $CollisionShape2D.shape
+@onready var shadow:Sprite2D = $ShadowSprite
 
 func _ready():
+	shadow.visible = false
 	_contained_elements.resize(GlobalConstants.Elements.size())
 	_contained_elements.fill(0)
 
@@ -47,6 +49,9 @@ func stop_movement():
 	_moving_to_target = false
 	_target_global_position = Vector2.ZERO
 
+func get_shadow():
+	return shadow
+
 	##################
 	# INPUT HANDLING #
 	##################
@@ -69,14 +74,16 @@ func draw_front(in_front:bool):
 
 func select_and_enlarge_backpack():
 	selected = true
-	$Sprite2D.apply_scale(
+	shadow.visible = true
+	$PackSprite.apply_scale(
 		Vector2(_scale_up_20_percent, _scale_up_20_percent)
 	)
 
 func stop_deselect_shrink_backpack():
 	stop_movement()
 	selected = false
-	$Sprite2D.apply_scale(
+	shadow.visible = false
+	$PackSprite.apply_scale(
 		Vector2(_scale_down_original, _scale_down_original)
 	)
 	_mouse_overlap_manual_check()

--- a/gameplay/Backpack.tscn
+++ b/gameplay/Backpack.tscn
@@ -15,6 +15,5 @@ shape = SubResource("RectangleShape2D_2k672")
 [node name="Sprite2D" type="Sprite2D" parent="."]
 texture = ExtResource("1_hbr8j")
 
-[connection signal="input_event" from="." to="." method="_on_input_event"]
 [connection signal="mouse_entered" from="." to="." method="_on_mouse_entered"]
 [connection signal="mouse_exited" from="." to="." method="_on_mouse_exited"]

--- a/gameplay/Backpack.tscn
+++ b/gameplay/Backpack.tscn
@@ -12,7 +12,13 @@ script = ExtResource("1_1wqex")
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("RectangleShape2D_2k672")
 
-[node name="Sprite2D" type="Sprite2D" parent="."]
+[node name="ShadowSprite" type="Sprite2D" parent="."]
+modulate = Color(0.407843, 0.407843, 0.407843, 0.47451)
+scale = Vector2(0.8, 0.8)
+texture = ExtResource("1_hbr8j")
+
+[node name="PackSprite" type="Sprite2D" parent="."]
+scale = Vector2(0.9, 0.9)
 texture = ExtResource("1_hbr8j")
 
 [connection signal="mouse_entered" from="." to="." method="_on_mouse_entered"]

--- a/gameplay/Gameplay.gd
+++ b/gameplay/Gameplay.gd
@@ -9,6 +9,7 @@ var mock_victory = false
 @onready var columns = $Columns.get_children() as Array[GameplayColumn]
 const NO_COLUMN:int = -1
 var hovered_column_index:int = NO_COLUMN
+var hovered_backpack:Backpack = null
 var selected_backpack:Backpack = null
 var selected_backpack_home_column:GameplayColumn = null
 
@@ -18,12 +19,13 @@ func _ready():
 	database.reset_values()
 	_set_mock_goal()
 	_init_backpack($Backpack)
+	_init_backpack($Backpack2)
 	_init_columns()
 
 func _init_backpack(backpack:Backpack):
 	backpacks.append(backpack)
-	backpack.connect("backpack_selected", _on_backpack_selected)
-	backpack.connect("backpack_released", _on_backpack_released)
+	backpack.backpack_entered.connect(_on_backpack_entered)
+	backpack.backpack_exited.connect(_on_backpack_exited)
 	
 func _init_columns():
 	for column in columns:
@@ -67,24 +69,47 @@ func _on_column_exited(column_index):
 	else:
 		print("gameplay controller deactivating ", column_index)
 		hovered_column_index = NO_COLUMN
+		
+# Handle active / inactive backpacks
+func _on_backpack_entered(backpack:Backpack):
+	hovered_backpack = backpack
 
-func _on_backpack_selected(backpack:Backpack):
+func _on_backpack_exited(backpack:Backpack):
+	if hovered_backpack == backpack:
+		hovered_backpack = null
+
+func _handle_backpack_selection():
+	print("selected backpack ", selected_backpack)
+	print("hovered backpack ", hovered_backpack)
+	if selected_backpack == null:
+		if hovered_backpack != null:
+			_select_backpack(hovered_backpack)
+	else:
+		_release_backpack()
+
+func _select_backpack(backpack:Backpack):
 	selected_backpack = backpack
-	backpack.reparent(self)
+	selected_backpack.reparent(self)
+	selected_backpack.select_and_enlarge_backpack()
 	for column in columns:
 		if column.current_backpack == selected_backpack:
 			selected_backpack_home_column = column
 
-func _on_backpack_released():
+func _release_backpack():
+	selected_backpack.deselect_and_shrink_backpack()
+	selected_backpack = null
 	var target_column:GameplayColumn
 	if hovered_column_index != NO_COLUMN:
 		target_column = columns[hovered_column_index]
 	else:
 		target_column = selected_backpack_home_column
-	move_backpack_to_column(selected_backpack, selected_backpack_home_column, target_column)
+	swap_column_backpacks(selected_backpack_home_column, target_column)
 
 # Temp Code to let us experiment with adding / hiding columns & moving backpack
 func _input(event):
+	if Input.is_action_just_pressed("gameplay_select"):
+		_handle_backpack_selection()
+	
 	if event.is_action_pressed("ui_right"):
 		shift_backpack_column(backpacks.front(), 1)
 	
@@ -98,7 +123,6 @@ func _input(event):
 		_attempt_to_hide_last_column()
 
 func shift_backpack_column(backpack:Backpack, shift_by:int):
-	var columns = $Columns.get_children() as Array[GameplayColumn]
 	var current_backpack_column_index = columns.size()
 	var last_visible_column_index = -1
 	for i in range(columns.size()):
@@ -120,12 +144,12 @@ func shift_backpack_column(backpack:Backpack, shift_by:int):
 			target_column_index += visible_column_count
 		target_column_index = target_column_index % visible_column_count
 	
-	move_backpack_to_column(backpack, columns[current_backpack_column_index], columns[target_column_index])
+	swap_column_backpacks(columns[current_backpack_column_index], columns[target_column_index])
 
-func move_backpack_to_column(backpack:Backpack, oldColumn:GameplayColumn, 
-		newColumn:GameplayColumn):
-	oldColumn.set_backpack(null)
-	newColumn.set_backpack(backpack)
+func swap_column_backpacks(column1:GameplayColumn, column2:GameplayColumn):
+	var swap = column1.current_backpack
+	column1.set_backpack(column2.current_backpack)
+	column2.set_backpack(swap)
 
 func _attempt_to_reveal_next_column():
 	for column in $Columns.get_children():

--- a/gameplay/Gameplay.gd
+++ b/gameplay/Gameplay.gd
@@ -43,6 +43,12 @@ func _increment_number_of_days():
 			"res://gameplay/game_finished/GameFinished.tscn"
 		)
 
+# handles backpack positioning after initial load + after new columns added
+func _on_columns_sort_children():
+	for column in columns:
+		if column.current_backpack != null:
+			column.snap_backpack_to_anchor()
+
 func _on_next_day_button_pressed():
 	_increment_number_of_days()
 
@@ -81,14 +87,13 @@ func _handle_backpack_selection():
 
 func _select_backpack(backpack:Backpack):
 	selected_backpack = backpack
-	selected_backpack.reparent(self)
 	selected_backpack.select_and_enlarge_backpack()
 	for column in columns:
 		if column.current_backpack == selected_backpack:
 			selected_backpack_home_column = column
 
 func _release_backpack():
-	selected_backpack.deselect_and_shrink_backpack()
+	selected_backpack.stop_deselect_shrink_backpack()
 	selected_backpack = null
 	var target_column:GameplayColumn
 	if hovered_column_index != NO_COLUMN:
@@ -156,5 +161,6 @@ func _attempt_to_hide_last_column():
 	for column in reversed_columns:
 		if column.visible:
 			column.visible = false
-			break
-	
+			return
+
+

--- a/gameplay/Gameplay.gd
+++ b/gameplay/Gameplay.gd
@@ -10,22 +10,8 @@ func _ready():
 	database.reset_values()
 	_set_mock_goal()
 
-func _attempt_to_hide_last_column():
-	var reversed_columns = $Columns.get_children()
-	reversed_columns.reverse()
-	for column in reversed_columns:
-		if column.visible:
-			column.visible = false
-			return
-
-func _attempt_to_reveal_next_column():
-	for column in $Columns.get_children():
-		if not column.visible:
-			column.visible = true
-			return
-
 func _on_columns_sort_children():
-	$Backpack.snap_position_to_column($Columns/GameplayColumn)
+	$Columns/GameplayColumn.set_backpack($Backpack)
 	$Backpack.visible = true
 
 func _increment_number_of_days():
@@ -49,12 +35,62 @@ func _set_mock_goal():
 		" to win!"
 	)
 
-# Temp Code to let us experiment with adding / hiding columns
+# Temp Code to let us experiment with adding / hiding columns & moving backpack
 func _input(event):
+	if event.is_action_pressed("ui_right"):
+		shift_backpack_column($Backpack, 1)
+	
+	if event.is_action_pressed("ui_left"):
+		shift_backpack_column($Backpack, -1)
+	
 	if event.is_action_pressed("ui_up"):
 		_attempt_to_reveal_next_column()
-		return
 
 	if event.is_action_pressed("ui_down"):
 		_attempt_to_hide_last_column()
-		return
+
+func shift_backpack_column(backpack:Backpack, shift_by:int):
+	var columns = $Columns.get_children() as Array[GameplayColumn]
+	var current_backpack_column_index = columns.size()
+	var last_visible_column_index = -1
+	for i in range(columns.size()):
+		if columns[i].current_backpack == backpack:
+			current_backpack_column_index = mini(current_backpack_column_index, i)
+		
+		if columns[i].visible == true:
+			last_visible_column_index = i 
+		else:
+			break;
+	
+	var visible_column_count = last_visible_column_index + 1
+	var target_column_index:int
+	if current_backpack_column_index > last_visible_column_index:
+		target_column_index = last_visible_column_index
+	else:
+		target_column_index = current_backpack_column_index + shift_by
+		if target_column_index < 0:
+			target_column_index += visible_column_count
+		target_column_index = target_column_index % visible_column_count
+	
+	move_backpack_to_column(backpack, columns[current_backpack_column_index], columns[target_column_index])
+
+func move_backpack_to_column(backpack:Backpack, oldColumn:GameplayColumn, 
+		newColumn:GameplayColumn):
+	oldColumn.set_backpack(null)
+	newColumn.set_backpack(backpack)
+
+func _attempt_to_reveal_next_column():
+	for column in $Columns.get_children():
+		if not column.visible:
+			column.visible = true
+			return
+
+func _attempt_to_hide_last_column():
+	var reversed_columns = $Columns.get_children()
+	reversed_columns = reversed_columns.slice(1) #Don't hide the last column if there's just one left.
+	reversed_columns.reverse()
+	for column in reversed_columns:
+		if column.visible:
+			column.visible = false
+			break
+	

--- a/gameplay/Gameplay.gd
+++ b/gameplay/Gameplay.gd
@@ -58,16 +58,10 @@ func _set_mock_goal():
 
 # Handle active / inactive columns
 func _on_column_entered(column_index):
-	if hovered_column_index != column_index && hovered_column_index != NO_COLUMN:
-		print("gameplay controller deactivating ", hovered_column_index)
 	hovered_column_index = column_index
-	print("gameplay controller activating ", hovered_column_index)
 
 func _on_column_exited(column_index):
-	if hovered_column_index != column_index:
-		print("gameplay controller found column ", column_index, " already inactive")
-	else:
-		print("gameplay controller deactivating ", column_index)
+	if hovered_column_index == column_index:
 		hovered_column_index = NO_COLUMN
 		
 # Handle active / inactive backpacks
@@ -79,8 +73,6 @@ func _on_backpack_exited(backpack:Backpack):
 		hovered_backpack = null
 
 func _handle_backpack_selection():
-	print("selected backpack ", selected_backpack)
-	print("hovered backpack ", hovered_backpack)
 	if selected_backpack == null:
 		if hovered_backpack != null:
 			_select_backpack(hovered_backpack)

--- a/gameplay/Gameplay.gd
+++ b/gameplay/Gameplay.gd
@@ -67,6 +67,7 @@ func _on_column_exited(column_index):
 
 func _on_backpack_selected(backpack:Backpack):
 	selected_backpack = backpack
+	backpack.reparent(self)
 	for column in columns:
 		if column.current_backpack == selected_backpack:
 			selected_backpack_home_column = column

--- a/gameplay/Gameplay.gd
+++ b/gameplay/Gameplay.gd
@@ -73,10 +73,12 @@ func _on_backpack_selected(backpack:Backpack):
 			selected_backpack_home_column = column
 
 func _on_backpack_released():
-	if hovered_column_index == NO_COLUMN:
-		pass #snap backpack back to home
+	var target_column:GameplayColumn
+	if hovered_column_index != NO_COLUMN:
+		target_column = columns[hovered_column_index]
 	else:
-		move_backpack_to_column(selected_backpack, selected_backpack_home_column, columns[hovered_column_index])
+		target_column = selected_backpack_home_column
+	move_backpack_to_column(selected_backpack, selected_backpack_home_column, target_column)
 
 # Temp Code to let us experiment with adding / hiding columns & moving backpack
 func _input(event):

--- a/gameplay/Gameplay.gd
+++ b/gameplay/Gameplay.gd
@@ -12,12 +12,19 @@ var hovered_column_index:int = NO_COLUMN
 var selected_backpack:Backpack = null
 var selected_backpack_home_column:GameplayColumn = null
 
+var backpacks:Array[Backpack] = []
+
 func _ready():
 	database.reset_values()
 	_set_mock_goal()
-	_init_backpack()
+	_init_backpack($Backpack)
 	_init_columns()
 
+func _init_backpack(backpack:Backpack):
+	backpacks.append(backpack)
+	backpack.connect("backpack_selected", _on_backpack_selected)
+	backpack.connect("backpack_released", _on_backpack_released)
+	
 func _init_columns():
 	for column in columns:
 		if column.current_backpack != null:
@@ -25,10 +32,6 @@ func _init_columns():
 			column.current_backpack.visible = true
 		column.connect("column_entered", _on_column_entered)
 		column.connect("column_exited", _on_column_exited)
-
-func _init_backpack():
-	$Backpack.connect("backpack_selected", _on_backpack_selected)
-	$Backpack.connect("backpack_released", _on_backpack_released)
 
 func _increment_number_of_days():
 	database.increment_day_count()
@@ -83,10 +86,10 @@ func _on_backpack_released():
 # Temp Code to let us experiment with adding / hiding columns & moving backpack
 func _input(event):
 	if event.is_action_pressed("ui_right"):
-		shift_backpack_column($Backpack, 1)
+		shift_backpack_column(backpacks.front(), 1)
 	
 	if event.is_action_pressed("ui_left"):
-		shift_backpack_column($Backpack, -1)
+		shift_backpack_column(backpacks.front(), -1)
 	
 	if event.is_action_pressed("ui_up"):
 		_attempt_to_reveal_next_column()

--- a/gameplay/Gameplay.gd
+++ b/gameplay/Gameplay.gd
@@ -15,6 +15,9 @@ var selected_backpack_home_column:GameplayColumn = null
 
 var backpacks:Array[Backpack] = []
 
+##################
+# INITIALIZATION #
+##################
 func _ready():
 	database.reset_values()
 	_set_mock_goal()
@@ -35,6 +38,15 @@ func _init_columns():
 		column.connect("column_entered", _on_column_entered)
 		column.connect("column_exited", _on_column_exited)
 
+# handles backpack positioning after initial load + after new columns added
+func _on_columns_sort_children():
+	for column in columns:
+		if column.current_backpack != null:
+			column.snap_backpack_to_anchor()
+
+#####################
+# NEXT DAY HANDLING #
+#####################
 func _increment_number_of_days():
 	database.increment_day_count()
 
@@ -42,12 +54,6 @@ func _increment_number_of_days():
 		get_tree().change_scene_to_file(
 			"res://gameplay/game_finished/GameFinished.tscn"
 		)
-
-# handles backpack positioning after initial load + after new columns added
-func _on_columns_sort_children():
-	for column in columns:
-		if column.current_backpack != null:
-			column.snap_backpack_to_anchor()
 
 func _on_next_day_button_pressed():
 	_increment_number_of_days()
@@ -62,15 +68,16 @@ func _set_mock_goal():
 		" to win!"
 	)
 
-# Handle active / inactive columns
+#############################
+# BACKPACK CONTROL HANDLING #
+#############################
 func _on_column_entered(column_index):
 	hovered_column_index = column_index
 
 func _on_column_exited(column_index):
 	if hovered_column_index == column_index:
 		hovered_column_index = NO_COLUMN
-		
-# Handle active / inactive backpacks
+
 func _on_backpack_entered(backpack:Backpack):
 	hovered_backpack = backpack
 
@@ -102,7 +109,9 @@ func _release_backpack():
 		target_column = selected_backpack_home_column
 	swap_column_backpacks(selected_backpack_home_column, target_column)
 
-# Temp Code to let us experiment with adding / hiding columns & moving backpack
+#############
+# TEMP CODE #
+#############
 func _input(event):
 	if Input.is_action_just_pressed("gameplay_select"):
 		_handle_backpack_selection()

--- a/gameplay/Gameplay.tscn
+++ b/gameplay/Gameplay.tscn
@@ -2,10 +2,10 @@
 
 [ext_resource type="Script" path="res://gameplay/Gameplay.gd" id="1_cv37s"]
 [ext_resource type="PackedScene" uid="uid://c25adoveil6xs" path="res://hud/CurrencySilverCoin.tscn" id="2_a1m00"]
-[ext_resource type="FontFile" uid="uid://cv7jguoc63tx5" path="res://fonts/Roboto/Roboto-Medium.ttf" id="2_ny8ex"]
+[ext_resource type="FontFile" uid="uid://d1faal3mxcb84" path="res://fonts/Roboto/Roboto-Medium.ttf" id="2_ny8ex"]
 [ext_resource type="PackedScene" uid="uid://dm07s06ryg2u" path="res://menus/BackToStartMenuButton.tscn" id="3_7t8p6"]
 [ext_resource type="Script" path="res://gameplay/NextDayButton.gd" id="4_fxq41"]
-[ext_resource type="FontFile" uid="uid://npuan5guuu1s" path="res://fonts/Roboto/Roboto-Regular.ttf" id="5_rf4ff"]
+[ext_resource type="FontFile" uid="uid://b0t1dk3g11t5r" path="res://fonts/Roboto/Roboto-Regular.ttf" id="5_rf4ff"]
 [ext_resource type="PackedScene" uid="uid://e1hatl7xepnb" path="res://hud/DaysPassedTracker.tscn" id="7_6ilhd"]
 [ext_resource type="PackedScene" uid="uid://dklr5kcqww66r" path="res://gameplay/GameplayColumn.tscn" id="8_pe5uu"]
 [ext_resource type="PackedScene" uid="uid://24e0kif4kkdt" path="res://gameplay/Backpack.tscn" id="9_6n0cn"]
@@ -96,30 +96,35 @@ grow_vertical = 2
 theme_override_constants/separation = 10
 alignment = 1
 
-[node name="GameplayColumn" parent="Columns" instance=ExtResource("8_pe5uu")]
+[node name="GameplayColumn" parent="Columns" node_paths=PackedStringArray("current_backpack") instance=ExtResource("8_pe5uu")]
 layout_mode = 2
+current_backpack = NodePath("../../Backpack")
 
 [node name="GameplayColumn2" parent="Columns" instance=ExtResource("8_pe5uu")]
 layout_mode = 2
+column_index = 1
 
 [node name="GameplayColumn3" parent="Columns" instance=ExtResource("8_pe5uu")]
 layout_mode = 2
+column_index = 2
 
 [node name="GameplayColumn4" parent="Columns" instance=ExtResource("8_pe5uu")]
 visible = false
 layout_mode = 2
+column_index = 3
 
 [node name="GameplayColumn5" parent="Columns" instance=ExtResource("8_pe5uu")]
 visible = false
 layout_mode = 2
+column_index = 4
 
 [node name="GameplayColumn6" parent="Columns" instance=ExtResource("8_pe5uu")]
 visible = false
 layout_mode = 2
+column_index = 5
 
 [node name="Backpack" parent="." instance=ExtResource("9_6n0cn")]
 visible = false
 
 [connection signal="timeout" from="MockExplanation/DelayHidingTitle" to="." method="_on_timer_timeout"]
 [connection signal="pressed" from="NextDay/NextDayButton" to="." method="_on_next_day_button_pressed"]
-[connection signal="sort_children" from="Columns" to="." method="_on_columns_sort_children"]

--- a/gameplay/Gameplay.tscn
+++ b/gameplay/Gameplay.tscn
@@ -2,10 +2,10 @@
 
 [ext_resource type="Script" path="res://gameplay/Gameplay.gd" id="1_cv37s"]
 [ext_resource type="PackedScene" uid="uid://c25adoveil6xs" path="res://hud/CurrencySilverCoin.tscn" id="2_a1m00"]
-[ext_resource type="FontFile" uid="uid://cddebactj84w3" path="res://fonts/Roboto/Roboto-Medium.ttf" id="2_ny8ex"]
+[ext_resource type="FontFile" uid="uid://cv7jguoc63tx5" path="res://fonts/Roboto/Roboto-Medium.ttf" id="2_ny8ex"]
 [ext_resource type="PackedScene" uid="uid://dm07s06ryg2u" path="res://menus/BackToStartMenuButton.tscn" id="3_7t8p6"]
 [ext_resource type="Script" path="res://gameplay/NextDayButton.gd" id="4_fxq41"]
-[ext_resource type="FontFile" uid="uid://c104v5f0ficln" path="res://fonts/Roboto/Roboto-Regular.ttf" id="5_rf4ff"]
+[ext_resource type="FontFile" uid="uid://npuan5guuu1s" path="res://fonts/Roboto/Roboto-Regular.ttf" id="5_rf4ff"]
 [ext_resource type="PackedScene" uid="uid://e1hatl7xepnb" path="res://hud/DaysPassedTracker.tscn" id="7_6ilhd"]
 [ext_resource type="PackedScene" uid="uid://dklr5kcqww66r" path="res://gameplay/GameplayColumn.tscn" id="8_pe5uu"]
 [ext_resource type="PackedScene" uid="uid://24e0kif4kkdt" path="res://gameplay/Backpack.tscn" id="9_6n0cn"]

--- a/gameplay/Gameplay.tscn
+++ b/gameplay/Gameplay.tscn
@@ -100,9 +100,10 @@ alignment = 1
 layout_mode = 2
 current_backpack = NodePath("../../Backpack")
 
-[node name="GameplayColumn2" parent="Columns" instance=ExtResource("8_pe5uu")]
+[node name="GameplayColumn2" parent="Columns" node_paths=PackedStringArray("current_backpack") instance=ExtResource("8_pe5uu")]
 layout_mode = 2
 column_index = 1
+current_backpack = NodePath("../../Backpack2")
 
 [node name="GameplayColumn3" parent="Columns" instance=ExtResource("8_pe5uu")]
 layout_mode = 2
@@ -125,6 +126,10 @@ column_index = 5
 
 [node name="Backpack" parent="." instance=ExtResource("9_6n0cn")]
 visible = false
+
+[node name="Backpack2" parent="." instance=ExtResource("9_6n0cn")]
+visible = false
+modulate = Color(0, 1, 0.231373, 1)
 
 [connection signal="timeout" from="MockExplanation/DelayHidingTitle" to="." method="_on_timer_timeout"]
 [connection signal="pressed" from="NextDay/NextDayButton" to="." method="_on_next_day_button_pressed"]

--- a/gameplay/Gameplay.tscn
+++ b/gameplay/Gameplay.tscn
@@ -133,3 +133,4 @@ modulate = Color(0, 1, 0.231373, 1)
 
 [connection signal="timeout" from="MockExplanation/DelayHidingTitle" to="." method="_on_timer_timeout"]
 [connection signal="pressed" from="NextDay/NextDayButton" to="." method="_on_next_day_button_pressed"]
+[connection signal="sort_children" from="Columns" to="." method="_on_columns_sort_children"]

--- a/gameplay/Gameplay.tscn
+++ b/gameplay/Gameplay.tscn
@@ -2,10 +2,10 @@
 
 [ext_resource type="Script" path="res://gameplay/Gameplay.gd" id="1_cv37s"]
 [ext_resource type="PackedScene" uid="uid://c25adoveil6xs" path="res://hud/CurrencySilverCoin.tscn" id="2_a1m00"]
-[ext_resource type="FontFile" uid="uid://d1faal3mxcb84" path="res://fonts/Roboto/Roboto-Medium.ttf" id="2_ny8ex"]
+[ext_resource type="FontFile" uid="uid://cv7jguoc63tx5" path="res://fonts/Roboto/Roboto-Medium.ttf" id="2_ny8ex"]
 [ext_resource type="PackedScene" uid="uid://dm07s06ryg2u" path="res://menus/BackToStartMenuButton.tscn" id="3_7t8p6"]
 [ext_resource type="Script" path="res://gameplay/NextDayButton.gd" id="4_fxq41"]
-[ext_resource type="FontFile" uid="uid://b0t1dk3g11t5r" path="res://fonts/Roboto/Roboto-Regular.ttf" id="5_rf4ff"]
+[ext_resource type="FontFile" uid="uid://npuan5guuu1s" path="res://fonts/Roboto/Roboto-Regular.ttf" id="5_rf4ff"]
 [ext_resource type="PackedScene" uid="uid://e1hatl7xepnb" path="res://hud/DaysPassedTracker.tscn" id="7_6ilhd"]
 [ext_resource type="PackedScene" uid="uid://dklr5kcqww66r" path="res://gameplay/GameplayColumn.tscn" id="8_pe5uu"]
 [ext_resource type="PackedScene" uid="uid://24e0kif4kkdt" path="res://gameplay/Backpack.tscn" id="9_6n0cn"]

--- a/gameplay/GameplayColumn.gd
+++ b/gameplay/GameplayColumn.gd
@@ -14,6 +14,13 @@ signal column_exited
 func get_anchor_point_position():
 	return anchor_point.global_position
 
+# Need during init to make collision check match the columns after auto-resize
+func _on_item_rect_changed():
+	$CenterPoint/Area2D/CollisionShape2D.shape.set_size(size)
+
+####################
+# BACKPACK CONTROL #
+####################
 func set_backpack(newBackpack:Backpack):
 	current_backpack = newBackpack
 	if current_backpack != null:
@@ -29,9 +36,9 @@ func snap_backpack_to_anchor():
 		current_backpack.global_position = anchor_point.global_position
 		current_backpack.stop_movement()
 
-func _on_item_rect_changed():
-	$CenterPoint/Area2D/CollisionShape2D.shape.set_size(size)
-
+##################
+# INPUT HANDLING #
+##################
 func _on_area_2d_mouse_entered():
 	column_entered.emit(column_index)
 

--- a/gameplay/GameplayColumn.gd
+++ b/gameplay/GameplayColumn.gd
@@ -17,6 +17,9 @@ func get_anchor_point_position():
 func set_backpack(newBackpack:Backpack):
 	current_backpack = newBackpack
 	if current_backpack != null:
+		var new_shadow = current_backpack.get_shadow()
+		new_shadow.reparent(anchor_point)
+		new_shadow.global_position = anchor_point.global_position
 		current_backpack.reparent(anchor_point)
 		current_backpack.set_target_position(anchor_point.global_position)
 	# backpack has potentially changed, re-evaluate column stuff

--- a/gameplay/GameplayColumn.gd
+++ b/gameplay/GameplayColumn.gd
@@ -21,16 +21,11 @@ func set_backpack(newBackpack:Backpack):
 		current_backpack.position = Vector2.ZERO
 	# backpack has potentially changed, re-evaluate column stuff
 
-func _on_mouse_entered():
-	print("entered at ", column_index)
-
 func _on_item_rect_changed():
 	$CenterPoint/Area2D/CollisionShape2D.shape.set_size(size)
 
 func _on_area_2d_mouse_entered():
-	print("shape entered at ", column_index)
 	column_entered.emit(column_index)
 
 func _on_area_2d_mouse_exited():
-	print("shape exited at ", column_index)
 	column_exited.emit(column_index)

--- a/gameplay/GameplayColumn.gd
+++ b/gameplay/GameplayColumn.gd
@@ -3,6 +3,9 @@ extends Control
 
 class_name GameplayColumn
 
+signal column_entered
+signal column_exited
+
 @export var column_index:int
 @export var current_backpack:Backpack
 
@@ -14,5 +17,20 @@ func get_anchor_point_position():
 func set_backpack(newBackpack:Backpack):
 	current_backpack = newBackpack
 	if current_backpack != null:
-		current_backpack.snap_position(anchor_point.global_position)
+		current_backpack.reparent(anchor_point)
+		current_backpack.position = Vector2.ZERO
 	# backpack has potentially changed, re-evaluate column stuff
+
+func _on_mouse_entered():
+	print("entered at ", column_index)
+
+func _on_item_rect_changed():
+	$CenterPoint/Area2D/CollisionShape2D.shape.set_size(size)
+
+func _on_area_2d_mouse_entered():
+	print("shape entered at ", column_index)
+	column_entered.emit(column_index)
+
+func _on_area_2d_mouse_exited():
+	print("shape exited at ", column_index)
+	column_exited.emit(column_index)

--- a/gameplay/GameplayColumn.gd
+++ b/gameplay/GameplayColumn.gd
@@ -18,8 +18,13 @@ func set_backpack(newBackpack:Backpack):
 	current_backpack = newBackpack
 	if current_backpack != null:
 		current_backpack.reparent(anchor_point)
-		current_backpack.position = Vector2.ZERO
+		current_backpack.set_target_position(anchor_point.global_position)
 	# backpack has potentially changed, re-evaluate column stuff
+
+func snap_backpack_to_anchor():
+	if current_backpack != null:
+		current_backpack.global_position = anchor_point.global_position
+		current_backpack.stop_movement()
 
 func _on_item_rect_changed():
 	$CenterPoint/Area2D/CollisionShape2D.shape.set_size(size)

--- a/gameplay/GameplayColumn.gd
+++ b/gameplay/GameplayColumn.gd
@@ -1,10 +1,18 @@
 # Column to reserve space for a region or a customer.
 extends Control
 
-var column_index = 1
+class_name GameplayColumn
 
-func _ready():
-	pass
+@export var column_index:int
+@export var current_backpack:Backpack
 
-func get_anchor_point():
-	return $AnchorPoint.global_position
+@onready var anchor_point:Control = $AnchorPoint
+
+func get_anchor_point_position():
+	return anchor_point.global_position
+
+func set_backpack(newBackpack:Backpack):
+	current_backpack = newBackpack
+	if current_backpack != null:
+		current_backpack.snap_position(anchor_point.global_position)
+	# backpack has potentially changed, re-evaluate column stuff

--- a/gameplay/GameplayColumn.tscn
+++ b/gameplay/GameplayColumn.tscn
@@ -25,11 +25,11 @@ color = Color(0.686275, 0.686275, 0.686275, 1)
 
 [node name="AnchorPoint" type="Control" parent="."]
 layout_mode = 1
-anchors_preset = 7
 anchor_left = 0.5
 anchor_top = 1.0
 anchor_right = 0.5
 anchor_bottom = 1.0
+offset_bottom = -64.0
 grow_horizontal = 2
 grow_vertical = 0
 

--- a/gameplay/GameplayColumn.tscn
+++ b/gameplay/GameplayColumn.tscn
@@ -1,6 +1,8 @@
-[gd_scene load_steps=2 format=3 uid="uid://dklr5kcqww66r"]
+[gd_scene load_steps=3 format=3 uid="uid://dklr5kcqww66r"]
 
 [ext_resource type="Script" path="res://gameplay/GameplayColumn.gd" id="1_n2apv"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_fj0u2"]
 
 [node name="GameplayColumn" type="Control"]
 custom_minimum_size = Vector2(128, 400)
@@ -30,3 +32,23 @@ anchor_right = 0.5
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 0
+
+[node name="CenterPoint" type="Control" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Area2D" type="Area2D" parent="CenterPoint"]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="CenterPoint/Area2D"]
+shape = SubResource("RectangleShape2D_fj0u2")
+debug_color = Color(0, 0.6, 0.701961, 0.419608)
+
+[connection signal="item_rect_changed" from="." to="." method="_on_item_rect_changed"]
+[connection signal="mouse_entered" from="CenterPoint/Area2D" to="." method="_on_area_2d_mouse_entered"]
+[connection signal="mouse_exited" from="CenterPoint/Area2D" to="." method="_on_area_2d_mouse_exited"]

--- a/gameplay/game_finished/GameFinished.tscn
+++ b/gameplay/game_finished/GameFinished.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=5 format=3 uid="uid://cly8rrgsjooew"]
 
-[ext_resource type="FontFile" uid="uid://ctwqdy5twnm7q" path="res://fonts/Roboto/Roboto-Black.ttf" id="2_gcbv0"]
+[ext_resource type="FontFile" uid="uid://kux3764h4qg1" path="res://fonts/Roboto/Roboto-Black.ttf" id="2_gcbv0"]
 [ext_resource type="PackedScene" uid="uid://e1hatl7xepnb" path="res://hud/DaysPassedTracker.tscn" id="3_edudb"]
 [ext_resource type="PackedScene" uid="uid://c25adoveil6xs" path="res://hud/CurrencySilverCoin.tscn" id="3_gv0k7"]
 [ext_resource type="PackedScene" uid="uid://dm07s06ryg2u" path="res://menus/BackToStartMenuButton.tscn" id="4_d0d6f"]

--- a/gameplay/game_finished/GameFinished.tscn
+++ b/gameplay/game_finished/GameFinished.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=5 format=3 uid="uid://cly8rrgsjooew"]
 
-[ext_resource type="FontFile" uid="uid://kux3764h4qg1" path="res://fonts/Roboto/Roboto-Black.ttf" id="2_gcbv0"]
+[ext_resource type="FontFile" uid="uid://cjycq52vwfpu7" path="res://fonts/Roboto/Roboto-Black.ttf" id="2_gcbv0"]
 [ext_resource type="PackedScene" uid="uid://e1hatl7xepnb" path="res://hud/DaysPassedTracker.tscn" id="3_edudb"]
 [ext_resource type="PackedScene" uid="uid://c25adoveil6xs" path="res://hud/CurrencySilverCoin.tscn" id="3_gv0k7"]
 [ext_resource type="PackedScene" uid="uid://dm07s06ryg2u" path="res://menus/BackToStartMenuButton.tscn" id="4_d0d6f"]

--- a/gameplay/item/Item.gd
+++ b/gameplay/item/Item.gd
@@ -1,0 +1,16 @@
+extends Resource
+
+class_name Item
+
+@export var name:String = ""
+@export var graphic:Texture2D
+
+@export var ele_nature:int = 0
+@export var ele_earth:int = 0
+@export var ele_fire:int = 0
+@export var ele_water:int = 0
+@export var ele_air:int = 0
+@export var ele_wild:int = 0
+
+var elements:Array[int] = [ele_nature, ele_earth, ele_fire, ele_water, ele_air, ele_wild]
+# can add other qualities that all items will have here

--- a/gameplay/item/rock.tres
+++ b/gameplay/item/rock.tres
@@ -1,0 +1,15 @@
+[gd_resource type="Resource" script_class="Item" load_steps=3 format=3 uid="uid://cbhyrlxjeqv7p"]
+
+[ext_resource type="Texture2D" uid="uid://brf4h74py8sal" path="res://icon.svg" id="1_uqfki"]
+[ext_resource type="Script" path="res://gameplay/item/Item.gd" id="1_ym2qo"]
+
+[resource]
+script = ExtResource("1_ym2qo")
+name = "rock"
+graphic = ExtResource("1_uqfki")
+ele_nature = 1
+ele_earth = 2
+ele_fire = 0
+ele_water = 0
+ele_air = 0
+ele_wild = 0

--- a/gameplay/util/GlobalConstants.gd
+++ b/gameplay/util/GlobalConstants.gd
@@ -1,0 +1,3 @@
+class_name GlobalConstants
+
+enum Elements {NATURE, EARTH, FIRE, WATER, AIR, WILD}

--- a/hud/CurrencySilverCoin.tscn
+++ b/hud/CurrencySilverCoin.tscn
@@ -1,8 +1,8 @@
 [gd_scene load_steps=4 format=3 uid="uid://c25adoveil6xs"]
 
 [ext_resource type="Script" path="res://hud/CurrencySilverCoin.gd" id="1_i1iqb"]
-[ext_resource type="Texture2D" uid="uid://bp3ph3aanfjn0" path="res://art/silver_coin.png" id="2_7gmhd"]
-[ext_resource type="FontFile" uid="uid://d4hul02h7mc5f" path="res://fonts/Roboto/Roboto-Medium.ttf" id="3_wkxmr"]
+[ext_resource type="Texture2D" uid="uid://dkew3i6wq7feh" path="res://art/silver_coin.png" id="2_7gmhd"]
+[ext_resource type="FontFile" uid="uid://d1faal3mxcb84" path="res://fonts/Roboto/Roboto-Medium.ttf" id="3_wkxmr"]
 
 [node name="CurrencySilverCoin" type="HBoxContainer"]
 anchors_preset = 15

--- a/menus/StartMenu.tscn
+++ b/menus/StartMenu.tscn
@@ -1,8 +1,8 @@
 [gd_scene load_steps=5 format=3 uid="uid://b7nqon34mqhr5"]
 
-[ext_resource type="FontFile" uid="uid://bhww3go5q6ukt" path="res://fonts/Roboto/Roboto-Bold.ttf" id="1"]
-[ext_resource type="FontFile" uid="uid://ctwqdy5twnm7q" path="res://fonts/Roboto/Roboto-Black.ttf" id="3_bmuqt"]
-[ext_resource type="FontFile" uid="uid://bfaytobi4bbyw" path="res://fonts/Roboto/Roboto-Regular.ttf" id="4_co7c5"]
+[ext_resource type="FontFile" uid="uid://dkh871r4vl1hr" path="res://fonts/Roboto/Roboto-Bold.ttf" id="1"]
+[ext_resource type="FontFile" uid="uid://cjycq52vwfpu7" path="res://fonts/Roboto/Roboto-Black.ttf" id="3_bmuqt"]
+[ext_resource type="FontFile" uid="uid://b0t1dk3g11t5r" path="res://fonts/Roboto/Roboto-Regular.ttf" id="4_co7c5"]
 [ext_resource type="Script" path="res://menus/StartMenu.gd" id="5"]
 
 [node name="StartMenu" type="Control"]

--- a/project.godot
+++ b/project.godot
@@ -21,9 +21,10 @@ Database="*res://data/database.gd"
 
 [input]
 
-click={
+gameplay_select={
 "deadzone": 0.5,
 "events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":false,"double_click":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":0,"echo":false,"script":null)
 ]
 }
 


### PR DESCRIPTION
## Completed Planned Features:
* Able to drag backpacks to snap into a column's tray.
* Add backpacks on start-up, x2.
* Backpacks expose functionality:
   * Can contain resources.
   * Define enum for currencies:
   * 6 elemental currencies. (12hr)
      * Nature
      * Earth
      * Fire
      * Water
      * Air
      * Wildcard (keep logic separate-ish though)
   * Report its contents.
   * Set to empty.
   * Check if full.
   * Add 1 resource (made of element components).
   * Change capacity.
  
## Completed Extra Features:
 * Dragging backpacks to an already-occupied column exchanges backpack positions
 * Backpacks slide to snap position (instead of teleporting)
 * Picked up backpack leaves behind a smaller "shadow" sprite to show where it came from.