### PR TITLE
bug-0 - fix double event handling bug.

### DIFF
--- a/gameplay/Gameplay.gd
+++ b/gameplay/Gameplay.gd
@@ -167,7 +167,7 @@ func _attempt_to_reveal_next_column() -> void:
 			return
 
 func _input(event):
-	if Input.is_action_just_pressed("gameplay_select"):
+	if event.is_action_pressed("gameplay_select"):
 		_handle_backpack_selection()
 	
 	if event.is_action_pressed("ui_right"):

--- a/gameplay/Gameplay.tscn
+++ b/gameplay/Gameplay.tscn
@@ -2,10 +2,10 @@
 
 [ext_resource type="Script" path="res://gameplay/Gameplay.gd" id="1_cv37s"]
 [ext_resource type="PackedScene" uid="uid://c25adoveil6xs" path="res://hud/CurrencySilverCoin.tscn" id="2_a1m00"]
-[ext_resource type="FontFile" uid="uid://cddebactj84w3" path="res://fonts/Roboto/Roboto-Medium.ttf" id="2_ny8ex"]
+[ext_resource type="FontFile" uid="uid://cv7jguoc63tx5" path="res://fonts/Roboto/Roboto-Medium.ttf" id="2_ny8ex"]
 [ext_resource type="PackedScene" uid="uid://dm07s06ryg2u" path="res://menus/BackToStartMenuButton.tscn" id="3_7t8p6"]
 [ext_resource type="Script" path="res://gameplay/NextDayButton.gd" id="4_fxq41"]
-[ext_resource type="FontFile" uid="uid://c104v5f0ficln" path="res://fonts/Roboto/Roboto-Regular.ttf" id="5_rf4ff"]
+[ext_resource type="FontFile" uid="uid://npuan5guuu1s" path="res://fonts/Roboto/Roboto-Regular.ttf" id="5_rf4ff"]
 [ext_resource type="PackedScene" uid="uid://e1hatl7xepnb" path="res://hud/DaysPassedTracker.tscn" id="7_6ilhd"]
 [ext_resource type="PackedScene" uid="uid://dklr5kcqww66r" path="res://gameplay/GameplayColumn.tscn" id="8_pe5uu"]
 [ext_resource type="PackedScene" uid="uid://24e0kif4kkdt" path="res://gameplay/Backpack.tscn" id="9_6n0cn"]


### PR DESCRIPTION
This happened because we mixed input handling styles. _input() method is called on any kind of input event happening - including things like mouse movement. By using event.is_action_pressed, we determine if the incoming event is of the specific kind of action we're looking for. If the event trigger _input is anything else, it won't pass the conditional check.

What we had in place before was different, though, it was a static method that checked if the 'gameplay_select' action had happened this frame. On the frame we clicked, this conditional evaluated would evaluate true every time it was checked. This means that if we clicked the mouse while moving, it would trigger to calls to _input (one for mouse movement and one for the click) and both would pass the conditional check because the mouse had been clicked during that frame.

This change is small, but it ensures that we only do _handle_backpack_selection for input events that are actually for 'gameplay_select' being triggered. No more having unrelated events occuring in the same frame as the click triggering the backpack behavior.