### PR TITLE
Regenerate uids AND Ignore Build Folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 export.cfg
 export_presets.cfg
 *.tmp
+build/
 
 # Imported translations (automatically generated from CSV files)
 *.translation

--- a/gameplay/Gameplay.tscn
+++ b/gameplay/Gameplay.tscn
@@ -2,14 +2,14 @@
 
 [ext_resource type="Theme" uid="uid://c1rbyyhtqrqqt" path="res://fonts/normal_font_theme.tres" id="1_43exs"]
 [ext_resource type="Script" path="res://gameplay/Gameplay.gd" id="1_cv37s"]
-[ext_resource type="Texture2D" uid="uid://bq5un3lfqh3ie" path="res://art/backgrounds/bargain_table.jpg" id="2_551k0"]
+[ext_resource type="Texture2D" uid="uid://43qw31c6dcje" path="res://art/backgrounds/bargain_table.jpg" id="2_551k0"]
 [ext_resource type="PackedScene" uid="uid://c25adoveil6xs" path="res://hud/CurrencySilverCoin.tscn" id="2_a1m00"]
 [ext_resource type="PackedScene" uid="uid://7hqfyc7u8h48" path="res://gameplay/upgrade/UpgradeMenu.tscn" id="2_nf7ra"]
-[ext_resource type="FontFile" uid="uid://cv7jguoc63tx5" path="res://fonts/Roboto/Roboto-Medium.ttf" id="2_ny8ex"]
+[ext_resource type="FontFile" uid="uid://cddebactj84w3" path="res://fonts/Roboto/Roboto-Medium.ttf" id="2_ny8ex"]
 [ext_resource type="PackedScene" uid="uid://dm07s06ryg2u" path="res://menus/BackToStartMenuButton.tscn" id="3_7t8p6"]
 [ext_resource type="Script" path="res://gameplay/NextDayButton.gd" id="4_fxq41"]
 [ext_resource type="PackedScene" uid="uid://e1hatl7xepnb" path="res://hud/DaysPassedTracker.tscn" id="7_6ilhd"]
-[ext_resource type="Texture2D" uid="uid://rvhnv7527uvk" path="res://art/right_arrow.png" id="9_oawgj"]
+[ext_resource type="Texture2D" uid="uid://cvpru133oby1q" path="res://art/right_arrow.png" id="9_oawgj"]
 
 [sub_resource type="Gradient" id="Gradient_les6x"]
 offsets = PackedFloat32Array(0, 0.799544, 1)

--- a/gameplay/game_finished/GameFinished.tscn
+++ b/gameplay/game_finished/GameFinished.tscn
@@ -5,7 +5,7 @@
 [ext_resource type="PackedScene" uid="uid://c25adoveil6xs" path="res://hud/CurrencySilverCoin.tscn" id="3_gv0k7"]
 [ext_resource type="PackedScene" uid="uid://dm07s06ryg2u" path="res://menus/BackToStartMenuButton.tscn" id="4_d0d6f"]
 [ext_resource type="Script" path="res://gameplay/game_finished/TradesMadeTracker.gd" id="4_pl6ob"]
-[ext_resource type="Texture2D" path="res://art/backgrounds/well_deserved_nap.jpg" id="6_2mm8t"]
+[ext_resource type="Texture2D" uid="uid://djghjno2ajqnp" path="res://art/backgrounds/well_deserved_nap.jpg" id="6_2mm8t"]
 
 [node name="GameFinished" type="Control"]
 layout_mode = 3

--- a/gameplay/upgrade/UpgradeMenu.tscn
+++ b/gameplay/upgrade/UpgradeMenu.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=3 format=3 uid="uid://7hqfyc7u8h48"]
 
 [ext_resource type="Script" path="res://gameplay/upgrade/UpgradeMenu.gd" id="1_2ene1"]
-[ext_resource type="Texture2D" uid="uid://bdg3cw7lto23m" path="res://art/level_up_icon.png" id="2_02syh"]
+[ext_resource type="Texture2D" uid="uid://n17heaoqvnbj" path="res://art/level_up_icon.png" id="2_02syh"]
 
 [node name="UpgradeMenu" type="MarginContainer"]
 offset_right = 97.0

--- a/menus/CreditsMenu.tscn
+++ b/menus/CreditsMenu.tscn
@@ -1,8 +1,8 @@
 [gd_scene load_steps=5 format=3 uid="uid://cl87ap5mgbyxq"]
 
 [ext_resource type="PackedScene" uid="uid://dm07s06ryg2u" path="res://menus/BackToStartMenuButton.tscn" id="1"]
-[ext_resource type="Theme" path="res://fonts/normal_font_theme.tres" id="1_12lkd"]
-[ext_resource type="Texture2D" path="res://art/backgrounds/grand_opening.jpg" id="2_vylv0"]
+[ext_resource type="Theme" uid="uid://c1rbyyhtqrqqt" path="res://fonts/normal_font_theme.tres" id="1_12lkd"]
+[ext_resource type="Texture2D" uid="uid://6yom13chrvpm" path="res://art/backgrounds/grand_opening.jpg" id="2_vylv0"]
 [ext_resource type="Script" path="res://menus/CreditsMenu.gd" id="4"]
 
 [node name="CreditsMenu" type="Control"]

--- a/menus/StartMenu.gd
+++ b/menus/StartMenu.gd
@@ -21,7 +21,7 @@ func _ready():
 	else:
 		_initial_scroll_background()
 	first_load = false
-	if OS.get_name() == "HTML5":
+	if OS.get_name() == "Web":
 		quit_button.visible = false
 
 func _on_CreditsButton_pressed() -> void:

--- a/menus/StartMenu.tscn
+++ b/menus/StartMenu.tscn
@@ -1,9 +1,9 @@
 [gd_scene load_steps=6 format=3 uid="uid://b7nqon34mqhr5"]
 
-[ext_resource type="FontFile" uid="uid://bu77pr0tn14rr" path="res://fonts/Roboto/Roboto-Bold.ttf" id="1"]
+[ext_resource type="FontFile" uid="uid://q3gqhife6qv" path="res://fonts/Roboto/Roboto-Bold.ttf" id="1"]
 [ext_resource type="Theme" uid="uid://c1rbyyhtqrqqt" path="res://fonts/normal_font_theme.tres" id="1_toiww"]
-[ext_resource type="Texture2D" uid="uid://bbltb0nt7c3jp" path="res://art/backgrounds/grand_opening.jpg" id="2_llt0a"]
-[ext_resource type="Texture2D" uid="uid://clb62ur83kib1" path="res://art/dialogue_box.png" id="4_vq270"]
+[ext_resource type="Texture2D" uid="uid://6yom13chrvpm" path="res://art/backgrounds/grand_opening.jpg" id="2_llt0a"]
+[ext_resource type="Texture2D" uid="uid://do6leyofrey0" path="res://art/dialogue_box.png" id="4_vq270"]
 [ext_resource type="Script" path="res://menus/StartMenu.gd" id="5"]
 
 [node name="StartMenu" type="Control"]


### PR DESCRIPTION
The build itself is uploaded to [itch.io on a restricted page](https://nbumgardner.itch.io/ludum-dare-54-packrat) for early playtesting as an HTML5 export.

## Implementation Details

Fixes a start-menu typo so that the Quit button hides correctly for web builds.

Mobile is not supported because Godot 4 is still working out its issues. An attempt was made by enabling `ETC2 ASTC` in Project Settings and exporting a mobile game loads on itch.io, but clicking play game leads to a 404 error.

### Screenshots

![pr-21_web-no-quit](https://github.com/SamBumgardner/packrat-game/assets/11843918/4c277b00-78c8-4708-90a8-0e1f780dad29)
_**Screenshot 1:** Screenshot of the itch.io hosted build of the game, with updated start menu display logic to hide the quit button since it would freeze the game._

![pr-21_local-quit-button](https://github.com/SamBumgardner/packrat-game/assets/11843918/7f633a4e-03d6-4560-9552-5554ec33190f)
_**Screenshot 2:** Local screenshot of the game running locally still showing the Quit button, as intended._